### PR TITLE
Add support for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,16 +42,14 @@ SOURCE_GROUP(engines FILES ${GSLICR_LIB})
 
 cuda_add_library(gSLICr_lib
 			${GSLICR_LIB}
-			NVTimer.h
-			OPTIONS -gencode arch=compute_30,code=compute_30)
+			NVTimer.h)
 target_link_libraries(gSLICr_lib ${CUDA_LIBRARY})
 
 cuda_add_library(DEMO SHARED
 			demo.cpp
 			${GSLICR_LIB}
-			NVTimer.h
-			OPTIONS -gencode arch=compute_30,code=compute_30)
+			NVTimer.h)
 target_link_libraries(DEMO ${OpenCV_LIBS})
 
-add_executable(demo demo.cpp)
-target_link_libraries(demo gSLICr_lib ${OpenCV_LIBS})
+add_executable(demo_executable demo.cpp)
+target_link_libraries(demo_executable gSLICr_lib ${OpenCV_LIBS})

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ make
 python3 example.py
 ```
 
+### A note for Windows users
+When building, run instead of running make, run `cmake --build . --config Release`.
+Before running the python script example.py, you need to change the line where the funciton `__get_CUDA_gSLICr__` is
+called to `__CUDA_gSLICr__ = __get_CUDA_gSLICr__("./build/Release/DEMO.dll")`. 
+
+
 ### Example
 
 ![original](https://github.com/mikigom/SLICrPy/blob/master/example.jpg?raw=true)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ python3 example.py
 ```
 
 ### A note for Windows users
-When building, run instead of running make, run `cmake --build . --config Release`.
+When building, instead of running `make`, run `cmake --build . --config Release`.
 Before running the python script example.py, you need to change the line where the funciton `__get_CUDA_gSLICr__` is
 called to `__CUDA_gSLICr__ = __get_CUDA_gSLICr__("./build/Release/DEMO.dll")`. 
 

--- a/demo.cpp
+++ b/demo.cpp
@@ -13,6 +13,15 @@
 #include "opencv2/highgui/highgui.hpp"
 #include "opencv2/imgproc/imgproc.hpp"
 
+#if defined _WIN32 || defined __CYGWIN__
+	#define DLLEXPORT __declspec(dllexport)
+	#define DLLIMPORT __declspec(dllimport)
+#else
+	#define DLLEXPORT
+	#define DLLIMPORT
+#endif
+
+
 #define color_space_XYZ 0
 #define color_space_LAB 1
 #define color_space_RGB 2
@@ -21,6 +30,7 @@ using namespace std;
 using namespace cv;
 
 extern "C"
+DLLEXPORT
 void load_image_from_Mat_to_UChar4(const Mat& inimg, gSLICr::UChar4Image* outimg)
 {
 	gSLICr::Vector4u* outimg_ptr = outimg->GetData(MEMORYDEVICE_CPU);
@@ -36,6 +46,7 @@ void load_image_from_Mat_to_UChar4(const Mat& inimg, gSLICr::UChar4Image* outimg
 }
 
 extern "C"
+DLLEXPORT
 void load_image_from_UChar4_to_Mat(const gSLICr::UChar4Image* inimg, Mat& outimg)
 {
 	const gSLICr::Vector4u* inimg_ptr = inimg->GetData(MEMORYDEVICE_CPU);
@@ -51,6 +62,7 @@ void load_image_from_UChar4_to_Mat(const gSLICr::UChar4Image* inimg, Mat& outimg
 }
 
 extern "C"
+DLLEXPORT
 void CUDA_gSLICr(unsigned char* image,
                  int img_size_x,
                  int img_size_y,


### PR DESCRIPTION
The project is very useful, but does not build on Windows 10 out of the box. I have suggested some changes for making the project build on Windows. (tested on Windows 10)

- demo.cpp: Export functions, so ctypes can access the functions in DEMO.dll
- CMakeLists.txt: Use default values for -gencode, compute_30 is deprecated in newer versions of nvcc. Changed the name of the executable to make the solution open correctly in Visual Studio. 
- README.md: Added a section for Windows users on how to build, and a reminder to call DEMO.dll instead of libDEMO.so. 

